### PR TITLE
 dynamo: Expose dynamodb instance

### DIFF
--- a/packages/dynamo/lib/Dynogels.d.ts
+++ b/packages/dynamo/lib/Dynogels.d.ts
@@ -1,5 +1,7 @@
+import { DynamoDB } from 'aws-sdk';
 export declare const is_real_db: boolean;
 declare function getEndPoint(): string;
+export declare const dynamodb: DynamoDB;
 declare function define(name: any, schema: any): any;
 declare const types: any;
 export { types, define, getEndPoint };

--- a/packages/dynamo/lib/Dynogels.js
+++ b/packages/dynamo/lib/Dynogels.js
@@ -7,7 +7,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const AWS = __importStar(require("aws-sdk"));
+const aws_sdk_1 = require("aws-sdk");
 const dynogels = __importStar(require("dynogels-promisified"));
 const Joi = __importStar(require("joi"));
 const _ = __importStar(require("lodash"));
@@ -22,30 +22,26 @@ function getEndPoint() {
     return 'http://localhost:11505';
 }
 exports.getEndPoint = getEndPoint;
-if (!exports.is_real_db) {
-    if (NODE_ENV === 'test') {
-        const dynamodb = new AWS.DynamoDB({
-            endpoint: getEndPoint(),
-            accessKeyId: 'mock',
-            secretAccessKey: 'mock',
-            region: 'us-east-1',
-        });
-        dynogels.dynamoDriver(dynamodb);
-    }
-    else {
-        const dynamodb = new AWS.DynamoDB({
-            endpoint: getEndPoint(),
-            region: 'localhost',
-        });
-        dynogels.dynamoDriver(dynamodb);
-    }
+let options;
+if (exports.is_real_db) {
+    options = { region: 'ap-northeast-2' };
+}
+else if (NODE_ENV === 'test') {
+    options = {
+        endpoint: getEndPoint(),
+        accessKeyId: 'mock',
+        secretAccessKey: 'mock',
+        region: 'us-east-1',
+    };
 }
 else {
-    const dynamodb = new AWS.DynamoDB({
-        region: 'ap-northeast-2',
-    });
-    dynogels.dynamoDriver(dynamodb);
+    options = {
+        endpoint: getEndPoint(),
+        region: 'localhost',
+    };
 }
+const dynamodb = new aws_sdk_1.DynamoDB(options);
+dynogels.dynamoDriver(dynamodb);
 function define(name, schema) {
     if (process.env.NODE_ENV === 'test') {
         schema.tableName = 'test-' + name;

--- a/packages/dynamo/lib/Dynogels.js
+++ b/packages/dynamo/lib/Dynogels.js
@@ -40,8 +40,8 @@ else {
         region: 'localhost',
     };
 }
-const dynamodb = new aws_sdk_1.DynamoDB(options);
-dynogels.dynamoDriver(dynamodb);
+exports.dynamodb = new aws_sdk_1.DynamoDB(options);
+dynogels.dynamoDriver(exports.dynamodb);
 function define(name, schema) {
     if (process.env.NODE_ENV === 'test') {
         schema.tableName = 'test-' + name;

--- a/packages/dynamo/src/Dynogels.ts
+++ b/packages/dynamo/src/Dynogels.ts
@@ -36,7 +36,7 @@ if (is_real_db) {
   };
 }
 
-const dynamodb = new DynamoDB(options);
+export const dynamodb = new DynamoDB(options);
 
 dynogels.dynamoDriver(dynamodb);
 

--- a/packages/dynamo/src/Dynogels.ts
+++ b/packages/dynamo/src/Dynogels.ts
@@ -1,4 +1,4 @@
-import * as AWS from 'aws-sdk';
+import { DynamoDB } from 'aws-sdk';
 
 import * as dynogels from 'dynogels-promisified';
 import * as Joi from 'joi';
@@ -18,28 +18,27 @@ function getEndPoint() {
   return 'http://localhost:11505';
 }
 
-if (!is_real_db) {
-  if (NODE_ENV === 'test') {
-    const dynamodb = new AWS.DynamoDB({
-      endpoint: getEndPoint(),
-      accessKeyId: 'mock',
-      secretAccessKey: 'mock',
-      region: 'us-east-1',
-    });
-    dynogels.dynamoDriver(dynamodb);
-  } else {
-    const dynamodb = new AWS.DynamoDB({
-      endpoint: getEndPoint(),
-      region: 'localhost',
-    });
-    dynogels.dynamoDriver(dynamodb);
-  }
+let options: DynamoDB.Types.ClientConfiguration;
+
+if (is_real_db) {
+  options = { region: 'ap-northeast-2' };
+} else if (NODE_ENV === 'test') {
+  options = {
+    endpoint: getEndPoint(),
+    accessKeyId: 'mock',
+    secretAccessKey: 'mock',
+    region: 'us-east-1',
+  };
 } else {
-  const dynamodb = new AWS.DynamoDB({
-    region: 'ap-northeast-2',
-  });
-  dynogels.dynamoDriver(dynamodb);
+  options = {
+    endpoint: getEndPoint(),
+    region: 'localhost',
+  };
 }
+
+const dynamodb = new DynamoDB(options);
+
+dynogels.dynamoDriver(dynamodb);
 
 function define(name, schema) {
   if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
Dynogels에서 미지원하는 `BatchWriteItem`를 위해 다른 라이브러리로 바꾸는게 너무 힘들 것 같아서..
dynamodb를 export하여 직접 호출해보려고 합니다.