### PR TITLE
express: Set loglevel of 304 and 404 to INFO

### DIFF
--- a/packages/express/src/logger.ts
+++ b/packages/express/src/logger.ts
@@ -159,10 +159,10 @@ export default (config: IExpressConfig) => {
       res.responseTime = Date.now() - start;
       // status code response level handling
       let level = log4js.levels.INFO;
-      if (res.statusCode >= 300) {
+      if (res.statusCode >= 300 && res.statusCode !== 304) {
         level = log4js.levels.WARN;
       }
-      if (res.statusCode >= 400) {
+      if (res.statusCode >= 400 && res.statusCode !== 404) {
         level = log4js.levels.ERROR;
       }
       const line = format(req, res);


### PR DESCRIPTION
hook에서 테스트 하다보니 favicon이 없어서 404인데 log4js가 ERROR로 남기고 레시피 필드 정의가 안 바껴서 304인데 WARN으로 남기길래
생각해보니 304 404는 항상 INFO로 남겨도 무방한 것 같아서 수정합니다.