### PR TITLE
graphql: Export function getFieldSet and getSubFieldNode

### DIFF
--- a/packages/graphql/lib/info/getFieldList.d.ts
+++ b/packages/graphql/lib/info/getFieldList.d.ts
@@ -1,3 +1,5 @@
-import { GraphQLResolveInfo } from 'graphql';
+import { FieldNode, FragmentDefinitionNode, GraphQLResolveInfo, InlineFragmentNode } from 'graphql';
+export declare const getFieldSet: (info: GraphQLResolveInfo, nodes: readonly (FieldNode | InlineFragmentNode | FragmentDefinitionNode)[], depth?: number) => Set<string>;
+export declare function getSubFieldNode(info: GraphQLResolveInfo, nodes: ReadonlyArray<FieldNode | InlineFragmentNode | FragmentDefinitionNode>, fieldName?: string): FieldNode | undefined;
 export declare function getFieldList(info: GraphQLResolveInfo, fieldName?: string): string[];
 export declare function getFieldList1st(info: GraphQLResolveInfo, fieldName?: string): string[];

--- a/packages/graphql/lib/info/getFieldList.js
+++ b/packages/graphql/lib/info/getFieldList.js
@@ -38,7 +38,7 @@ function getFieldSetWithPrefix(info, nodes, depth, prefix) {
         }
     }, new Set());
 }
-const getFieldSet = (info, nodes, depth = 99999) => getFieldSetWithPrefix(info, nodes, depth, '');
+exports.getFieldSet = (info, nodes, depth = 99999) => getFieldSetWithPrefix(info, nodes, depth, '');
 function getSubFieldNode(info, nodes, fieldName) {
     const selections = nodes.reduce((current, source) => {
         if (source && source.selectionSet && source.selectionSet.selections) {
@@ -66,21 +66,22 @@ function getSubFieldNode(info, nodes, fieldName) {
         }
     }
 }
+exports.getSubFieldNode = getSubFieldNode;
 function getFieldList(info, fieldName) {
     if (fieldName) {
         const node = getSubFieldNode(info, info.fieldNodes, fieldName);
-        return node ? [...getFieldSet(info, [node])] : [];
+        return node ? [...exports.getFieldSet(info, [node])] : [];
     }
     else {
-        return [...getFieldSet(info, info.fieldNodes)];
+        return [...exports.getFieldSet(info, info.fieldNodes)];
     }
 }
 exports.getFieldList = getFieldList;
 function getFieldList1st(info, fieldName) {
     if (fieldName) {
         const node = getSubFieldNode(info, info.fieldNodes, fieldName);
-        return node ? [...getFieldSet(info, [node], 1)] : [];
+        return node ? [...exports.getFieldSet(info, [node], 1)] : [];
     }
-    return [...getFieldSet(info, info.fieldNodes, 1)];
+    return [...exports.getFieldSet(info, info.fieldNodes, 1)];
 }
 exports.getFieldList1st = getFieldList1st;

--- a/packages/graphql/lib/info/index.d.ts
+++ b/packages/graphql/lib/info/index.d.ts
@@ -1,15 +1,15 @@
 import { GraphQLInputType, GraphQLResolveInfo, GraphQLSchema } from 'graphql';
 import { addArgumentToInfo, IAddArgumentToInfoOptions } from './addArgumentToInfo';
-export { addArgumentToInfo };
 import { addFieldToInfo, IAddFieldToInfoOptions } from './addFieldToInfo';
-export { addFieldToInfo };
 import { conformInfoToSchema } from './conformInfoToSchema';
-export { conformInfoToSchema };
-export { getFieldList, getFieldList1st } from './getFieldList';
-export { getFieldString } from './getFieldString';
 import { removeArgumentFromInfo } from './removeArgumentFromInfo';
+import { IRemoveFieldFromInfoOptions, removeFieldFromInfo } from './removeFieldFromInfo';
+export { addArgumentToInfo };
+export { addFieldToInfo };
+export { conformInfoToSchema };
+export { getFieldSet, getSubFieldNode, getFieldList, getFieldList1st } from './getFieldList';
+export { getFieldString } from './getFieldString';
 export { removeArgumentFromInfo };
-import { removeFieldFromInfo, IRemoveFieldFromInfoOptions } from './removeFieldFromInfo';
 export { removeFieldFromInfo };
 export interface IGraphQLResolveInfoMethods {
     addArgument(name: string, value: any, type: GraphQLInputType, options?: IAddArgumentToInfoOptions): this;

--- a/packages/graphql/lib/info/index.js
+++ b/packages/graphql/lib/info/index.js
@@ -6,15 +6,17 @@ const addFieldToInfo_1 = require("./addFieldToInfo");
 exports.addFieldToInfo = addFieldToInfo_1.addFieldToInfo;
 const conformInfoToSchema_1 = require("./conformInfoToSchema");
 exports.conformInfoToSchema = conformInfoToSchema_1.conformInfoToSchema;
-var getFieldList_1 = require("./getFieldList");
-exports.getFieldList = getFieldList_1.getFieldList;
-exports.getFieldList1st = getFieldList_1.getFieldList1st;
-var getFieldString_1 = require("./getFieldString");
-exports.getFieldString = getFieldString_1.getFieldString;
 const removeArgumentFromInfo_1 = require("./removeArgumentFromInfo");
 exports.removeArgumentFromInfo = removeArgumentFromInfo_1.removeArgumentFromInfo;
 const removeFieldFromInfo_1 = require("./removeFieldFromInfo");
 exports.removeFieldFromInfo = removeFieldFromInfo_1.removeFieldFromInfo;
+var getFieldList_1 = require("./getFieldList");
+exports.getFieldSet = getFieldList_1.getFieldSet;
+exports.getSubFieldNode = getFieldList_1.getSubFieldNode;
+exports.getFieldList = getFieldList_1.getFieldList;
+exports.getFieldList1st = getFieldList_1.getFieldList1st;
+var getFieldString_1 = require("./getFieldString");
+exports.getFieldString = getFieldString_1.getFieldString;
 function wrapInfo(info) {
     return Object.assign(Object.assign({}, info), { addArgument(name, value, type, options) { return addArgumentToInfo_1.addArgumentToInfo(this, name, value, type, options); },
         addField(name, options) { return addFieldToInfo_1.addFieldToInfo(this, name, options); },

--- a/packages/graphql/src/info/getFieldList.ts
+++ b/packages/graphql/src/info/getFieldList.ts
@@ -46,13 +46,13 @@ function getFieldSetWithPrefix(
   }, new Set<string>());
 }
 
-const getFieldSet = (
+export const getFieldSet = (
   info: GraphQLResolveInfo,
   nodes: ReadonlyArray<FieldNode | InlineFragmentNode | FragmentDefinitionNode>,
   depth: number = 99999,
 ): Set<string> => getFieldSetWithPrefix(info, nodes, depth, '');
 
-function getSubFieldNode(
+export function getSubFieldNode(
   info: GraphQLResolveInfo,
   nodes: ReadonlyArray<FieldNode | InlineFragmentNode | FragmentDefinitionNode>,
   fieldName?: string,

--- a/packages/graphql/src/info/index.ts
+++ b/packages/graphql/src/info/index.ts
@@ -1,16 +1,17 @@
 import { GraphQLInputType, GraphQLResolveInfo, GraphQLSchema } from 'graphql';
 
 import { addArgumentToInfo, IAddArgumentToInfoOptions } from './addArgumentToInfo';
-export { addArgumentToInfo };
 import { addFieldToInfo, IAddFieldToInfoOptions } from './addFieldToInfo';
-export { addFieldToInfo };
 import { conformInfoToSchema } from './conformInfoToSchema';
-export { conformInfoToSchema };
-export { getFieldList, getFieldList1st } from './getFieldList';
-export { getFieldString } from './getFieldString';
 import { removeArgumentFromInfo } from './removeArgumentFromInfo';
+import { IRemoveFieldFromInfoOptions, removeFieldFromInfo } from './removeFieldFromInfo';
+
+export { addArgumentToInfo };
+export { addFieldToInfo };
+export { conformInfoToSchema };
+export { getFieldSet, getSubFieldNode, getFieldList, getFieldList1st } from './getFieldList';
+export { getFieldString } from './getFieldString';
 export { removeArgumentFromInfo };
-import { removeFieldFromInfo, IRemoveFieldFromInfoOptions } from './removeFieldFromInfo';
 export { removeFieldFromInfo };
 
 export interface IGraphQLResolveInfoMethods {


### PR DESCRIPTION
지금은 info 기준 1depth 아래의 필드 목록만 알 수 있는데 더 밑을 알아야 하는 경우가 생겼습니다. 여기에 구현할까 하다가, 두 함수만 노출해줘도 바깥에서 쉽게 할 수 있기 때문에 안전하게 노출해서 바깥에서 해보려고 합니다.

- `getFieldSet`가 JavaScript Object를 사용하던 것을 Set을 사용하게 변경했습니다.
- `getFieldSet`의 `depth` parameter의 default 값을 99999로 지정했습니다.
- `getFieldSet`의 `prefix` parameter는 recursion 전용이므로 노출하지 않기 위해 recursive function으로 로직을 분리했습니다.
- `getFieldSet`와 `getSubFieldNode`을 export했습니다.