### PR TITLE
feat(express): add login_user_account_id to access log

### DIFF
--- a/packages/express/.changeset/proud-lions-report.md
+++ b/packages/express/.changeset/proud-lions-report.md
@@ -1,0 +1,5 @@
+---
+'@croquiscom/crary-express': minor
+---
+
+add login_user_account_id to access log

--- a/packages/express/lib/logger.js
+++ b/packages/express/lib/logger.js
@@ -85,6 +85,7 @@ exports.default = (config) => {
                     session_given: given_session?.substring(0, 6),
                     session_changed: this.C.s !== given_session,
                     user_id: req.session?.user_id,
+                    login_user_account_id: req.session?.login_user_account_id,
                     user_uuid: req.session?.uuid?.substring(0, 6),
                     request_method: this.I.m,
                     request_url: this.I.u,

--- a/packages/express/src/logger.ts
+++ b/packages/express/src/logger.ts
@@ -84,6 +84,7 @@ export default (config: IExpressConfig) => {
           session_given: given_session?.substring(0, 6),
           session_changed: this.C.s !== given_session,
           user_id: (req.session as any)?.user_id,
+          login_user_account_id: (req.session as any)?.login_user_account_id,
           user_uuid: (req.session as any)?.uuid?.substring(0, 6),
           request_method: this.I.m,
           request_url: this.I.u,


### PR DESCRIPTION
Add `login_user_account_id` from the session to the access log output, next to `user_id`.

Services that keep the logged-in account id in the session can then attribute access-log traffic to an account (e.g. identifying suspicious crawling accounts).

- `packages/express/src/logger.ts`: add the field to the log JSON output
- changeset: minor (→ 2.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)